### PR TITLE
BUGFIX: swap array_flatten with IncompatibleTypeError::flatArray

### DIFF
--- a/src/IncompatibleTypeError.php
+++ b/src/IncompatibleTypeError.php
@@ -242,7 +242,7 @@ final class IncompatibleTypeError extends \TypeError {
           return $th->getMessages($path) ;
         }, $this->previous);
 
-        $messages = array_flatten($messages);
+        $messages = static::flatArray($messages);
 
         if ($messages) {
           return $messages;


### PR DESCRIPTION
The function array_flatten() doesnt exists:
Call to undefined function Duck\Types\array_flatten()

Instead i saw you made a helper: IncompatibleTypeError::flatArray which will be used with this PR.